### PR TITLE
Set the position of the lootselection div to fixed

### DIFF
--- a/style.css
+++ b/style.css
@@ -233,7 +233,6 @@ a:active
 	margin:10px;
 	margin-left:600px;
 	height:541px;
-	overflow-y:scroll;
 	overflow-x:hidden;
 
 }
@@ -268,6 +267,14 @@ a:active
 	height:40px;
 	border-radius:50px;
 	margin-left:10px;
+}
+#lootselection {
+	position: fixed;
+}
+#loot {
+	margin-top:84px;
+	height: 444px;
+	overflow-y: auto;
 }
 
 .floatbox{


### PR DESCRIPTION
While playing the game, I kept getting annoyed by the amount of scrolling necessary to be able to hide lists of available and earned badges. If that's by design, then feel free to reject this.
