### PR TITLE
add .shop selector for grey shop icons just in case

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -1950,7 +1950,7 @@ Molpy.Up=function()
 			Molpy.BoostN++;
 			if(this.icon)
 			{
-				addCSSRule(document.styleSheets[1], '#boost_' + this.icon, "background-image:url('img/boost_" + this.icon + "_grey_icon.png' )");
+				addCSSRule(document.styleSheets[1], '.shop #boost_' + this.icon, "background-image:url('img/boost_" + this.icon + "_grey_icon.png' )");
 			}
 			return this;
 		}	


### PR DESCRIPTION
there didn't seem to be any conflicts yet, but this should prevent shop
vs loot icon type conflicts if things get refactored later
