### PR TITLE
1NP should contain exactly 1000 mNP

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -3465,8 +3465,10 @@ Molpy.Up=function()
 	+++++++++++++++++++++++++++++++++++*/
 	Molpy.Loopist=function()
 	{
+		var t = Molpy.time;
+		Molpy.time = new Date().getTime();
 		Molpy.ketchupTime=0;
-		Molpy.lateness+=((new Date().getTime()-Molpy.time));
+		Molpy.lateness+=(Molpy.time-t);
 		Molpy.lateness=Math.min(Molpy.lateness, 7200);//don't ketchup up too much
 		while(Molpy.lateness > Molpy.NPlength)
 		{
@@ -3490,7 +3492,6 @@ Molpy.Up=function()
 			throw e;
 			return;
 		}
-		Molpy.time=new Date().getTime();
 		setTimeout(Molpy.Loopist, 1000/Molpy.fps);
 	}	
 }


### PR DESCRIPTION
Molpy.time is generally not set to the same time as what was used to compute
lateness.  This introduces skew if drawing and/or thinking takes too much time.
This caused less than 1000 mNP per NP, and also slow countdown timers.

Apparently, I should not change a branch after sending a pull request :(
