### PR TITLE
Ninja Ritual doesn't activate when ninjaing infinite or mustard NewPixBots

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -465,7 +465,7 @@ Molpy.Up = function() {
 			}
 			Molpy.beachClicks += 1;
 			Molpy.CheckClickAchievements();
-			if(Molpy.ninjad == 0 && Molpy.CastleTools['NewPixBot'].amount) {
+			if(Molpy.ninjad == 0 && (!isFinite(Molpy.CastleTools['NewPixBot'].amount) || Molpy.CastleTools['NewPixBot'].amount) {
 				if(Molpy.npbONG == 1) {
 					Molpy.StealthClick();
 					Molpy.Boosts['Ninja Ritual'].Level = 0;


### PR DESCRIPTION
Since Ninja Herder works fine, I'm assuming this is unintentional.
