### PR TITLE
Glass Storage's classChange doesn't look at unlockable boosts & other obvious classChanges

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -5074,6 +5074,9 @@ Molpy.DefineBoosts = function() {
 		buyFunction: function() {
 			this.Level = (Molpy.Earned('Planck Limit') ? 6.2e34 : 1);
 		}
+		
+		// deactivate when reached max
+		classChange: function() { return (Molpy.Earned('Planck Limit')) ? 'action' : '';}
 	});
 	
 	Molpy.ControlAutomata = function(n, dragon) {
@@ -5586,8 +5589,7 @@ Molpy.DefineBoosts = function() {
 		GlassBlocks: '7P',
 		
 		// deactivate when reached max
-		classChange: function() {
-			return (Molpy.Boosts['AC'].Level = 6.2e34) ? 'action' : '';}
+		classChange: function() { return (Molpy.Earned('Planck Limit')) ? 'action' : '';}
 	});
 	new Molpy.Boost({
 		name: 'Crouching Dragon, Sleeping Panther',


### PR DESCRIPTION
Also includes other classChanges such as untagging Automata-related boosts from showing when owning Planck Limit, Fast Foward/Now Where Was I? when at the highest newPix and so on.
