### PR TITLE
Fixed possible boost total error

### DIFF
--- a/persist.js
+++ b/persist.js
@@ -900,7 +900,7 @@
 				Molpy.boostRepaint = 1;
 				Molpy.BoostsOwned++;
 			}
-			if(Molpy.Has('Blackprints', 1)){
+			else if(Molpy.Has('Blackprints', 1)){
 				Molpy.UnlockBoost('Blackprints');
 				Molpy.Boosts['Blackprints'].bought = 1;
 				Molpy.boostRepaint = 1;


### PR DESCRIPTION
Well it just occured to me that my fix for auto-buying blackprints could kinda add an extra, unexistant boost to the boost count. Relatively minor, but it really shouldn't do that anyway.
