### PR TITLE
Remove Caged Logicate save/reload exploit

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -3382,8 +3382,11 @@ Molpy.DefineBoosts = function() {
 		
 		refreshFunction: function() {
 			Molpy.ChainRefresh('ShadwDrgn');
-		}
-	});
+		},
+
+        loadFunction: function() { Molpy.PuzzleGens.caged.active=false; }
+
+    });
 
 	new Molpy.Puzzle('caged', function() {
 		Molpy.Boosts['LogiPuzzle'].Refresh();


### PR DESCRIPTION
Saving/Reloading didn't clear the Logicat puzzle, but kept the limit from the saved game, allowing unlimited logicats per NP. 
