### PR TITLE
Fix finite castles from infinite sand

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -181,7 +181,7 @@ Molpy.Up = function() {
 				Molpy.prevCastleSand = Molpy.currentCastleSand;
 				if(!isFinite(Molpy.Boosts['Sand'].power) || Molpy.nextCastleSand <= 0) {
 					Molpy.nextCastleSand = 1;
-					Molpy.Boosts['Castles'].power;
+					Molpy.Boosts['Castles'].power = Infinity;
 					Molpy.Boosts['Castles'].bought = Infinity;
 					return;
 				}


### PR DESCRIPTION
Infinite castle production broke here: https://github.com/eternaldensity/Sandcastle-Builder/commit/5e5f5b3c69ad1bf4bb2ae5e13f6bc84cb50aff2e#diff-2893769a29f832518410bc856e31cf7fL182

Only patched now because Git doesn't like edit conflicts. 
