### PR TITLE
Fix Blast furnace spam

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -4868,6 +4868,7 @@ Molpy.DefineBoosts = function() {
 			Molpy.DoMouldWork(left);
 		}
 
+		Molpy.boostSilence++;
 		var furn = Math.floor((times + Math.random() * 3) / 2);
 		if(Molpy.Got('Stretchable Chip Storage'))
 			Molpy.RewardBlastFurnace(furn);
@@ -4876,7 +4877,6 @@ Molpy.DefineBoosts = function() {
 				Molpy.RewardBlastFurnace();
 		}
 		left = times - furn;
-		Molpy.boostSilence++;
 		if(left > 7 && Molpy.Got('Milo')) {
 			var mr = Molpy.Boosts['Milo'];
 			var s = 0;// Math.sin((Math.PI*Molpy.ONGelapsed)/(Molpy.NPlength*100));


### PR DESCRIPTION
Picked up a save where Blast Furnace would constantly spam messages: http://pastebin.com/viMWwXZW

Note that the spam doesn't occur in latest SVN, due to patch on Molpy.Dig, but there may still be a corner case where it triggers. 
