### PR TITLE
Fix Jamming countdown resetting

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -6305,9 +6305,10 @@ Molpy.DefineBoosts = function() {
 			GlassBlocks: function() {
 				return 8e9 * Molpy.CastleTools['NewPixBot'].amount;
 			},
+		},
+
 		buyFunction: function() {
 			if (Molpy.Got('Jamming')) Molpy.Boosts['Jamming'].countdown = 20;
-			},
 
 		},
 	}); // www.youtube.com/watch?v=84q0SXW781c


### PR DESCRIPTION
A swapped close bracket caused the Fireproof buyFunction to run as part of it's price, so it resets Jamming's countdown every time any boost is locked or unlocked.
