### PR TITLE
Molpy.needlePulling = 0; in persist

### DIFF
--- a/persist.js
+++ b/persist.js
@@ -698,7 +698,7 @@
 		return 1;
 	}
 
-	Molpy.needlePulling = 1;
+	Molpy.needlePulling = 0;
 	Molpy.FromNeedlePulledThing = function(thread) {
 		Molpy.needlePulling = 1; //prevent earning badges that haven't been loaded
 		var p = 'P'; //Pipe seParator


### PR DESCRIPTION
Someone set this to 1 for some reason, and it broke stuff. If it was for
some fix, it wasn't fixed right, but hopefully it was just for testing and got overlooked.
