### PR TITLE
Redacted Rescue

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -561,7 +561,7 @@ Molpy.DefineGUI = function() {
 
 		var redactedIndex = -1;
 		if(Molpy.Redacted.location == 3) {
-			if(Molpy.Redacted.dispIndex == -1) {
+			if(Molpy.Redacted.dispIndex == -1 || Molpy.Redacted.dispIndex > Molpy.BoostsInShop.length + 1) {
 				Molpy.Redacted.dispIndex = Math.floor((Molpy.BoostsInShop.length + 1) * Math.random());
 			}
 			redactedIndex = Molpy.Redacted.dispIndex;


### PR DESCRIPTION
Redacted could get lost if they were in the bottom of the boost shop,
and boosts above them were bought (or locked).  They will now be
humanely relocated.  Fixes #708, fixes #482
