### PR TITLE
Change to loading with 'The Ritual is worn out'

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -8332,7 +8332,7 @@ Molpy.DefineBoosts = function() {
 		
 		price: {Goats: 300},
 		defStuff: 1,
-		loadFunction: function() { if (Molpy.Earned('The Ritual is worn out')) this.Level = Infinity },
+		loadFunction: function() { if (Molpy.Earned('The Ritual is worn out')) this.Level = 1e298 },
 	});
 	Molpy.NinjaRitual = function() {
 		var oldlvl = Molpy.Level('Ninja Ritual');


### PR DESCRIPTION
The load function for Ninja Ritual with 'The Ritual is worn out' badge was setting the Ninja Ritual level to Infinity. There was no benefit gained from this as with the badge earned the code follows a path involving a constant 1e298 rather than the ritual level variable.
Displaying infinity would cause a little confusing as you do not get infinity/5 goats.
It also had a downside of causing the ritual rift to cost infinity flux crystal.

I changed the value in the load function to 1e298 so that it reflects the constant used in the worn out branch of the goat reward code.
