### PR TITLE
Mustard/click display reflects cress when cress in effect.

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -710,7 +710,7 @@ Molpy.Up = function() {
 			this.getProduction = function() {
 				var production = '';
 				if(isNaN(this.amount))
-					production = 'Mustard/click: ' + Molpify((Molpy.Got('Cress')&&Molpy.IsEnabled('Cress')) ? Math.floor(Molpy.Boosts['Goats'].power/1000) : 1);
+					production = 'Mustard/click: ' + Molpify((Molpy.Got('Cress')&&Molpy.IsEnabled('Cress')) ? (Molpy.Boosts['Goats'].power/1000) : 1 , 3);
 				else if(this.storedTotalGpmNP)
 					production = 'Glass/mNP: ' + Molpify(this.storedTotalGpmNP, (this.storedTotalGpmNP < 10 ? 3 : 1));
 				else
@@ -1107,7 +1107,7 @@ Molpy.Up = function() {
 			this.getProduction = function() {
 				var production = '';
 				if(isNaN(this.amount))
-					production += 'Mustard/click: ' + Molpify((Molpy.Got('Cress')&&Molpy.IsEnabled('Cress')) ? Math.floor(Molpy.Boosts['Goats'].power/1000) : 1);
+					production += 'Mustard/click: ' + Molpify((Molpy.Got('Cress')&&Molpy.IsEnabled('Cress')) ? (Molpy.Boosts['Goats'].power/1000) : 1 , 3);
 				if(this.currentActive && Molpy.CastleTools['NewPixBot'].ninjaTime > Molpy.ONGelapsed) {
 					if(Molpy.ninjad) {
 						production += "Ninja'd!";


### PR DESCRIPTION
!!! Note: During testing found that mustard production is broken but I don't think it is related to my changes, I forked off master branch with dragon stuff.
Cress on or off no mustard is produced and no on screen notifications about mustard production appear.
!!!

After reading http://en.reddit.com/r/SandcastleBuilder/comments/24cgub/papal_boost_to_mustard_isnt_working/
I had noted that my tools were indicating that they produced 1 mustard per click despite having Cress and many goats and the notifications on screen to the contrary.

I made an effort to duplicate the appearance of the other states but fixed the Molpify to 3 digits so that it displays 0.### if goats are less than 1000.
