### PR TITLE
reflect pyric deaths in total dragons lost

### DIFF
--- a/dragons.js
+++ b/dragons.js
@@ -776,6 +776,7 @@ Molpy.OpponentsAttack = function(where,from,text1,text2) {
 		case 1 : // Pyric victory - lose a dragon...
 			var dloss = 0;
 			if (npd.amount > 1) {
+				dq.Loose(npd.DragonType,1);
 				npd.amount--;
 				dloss = 1;
 				factor *=2;


### PR DESCRIPTION
Reddit thread:
http://www.reddit.com/r/SandcastleBuilder/comments/2aptqg/dragons_lost_fighting/

Added a single line that should properly credit those deaths going forward to the loses array and total loses.
