### PR TITLE
Strength potion return error

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -10250,7 +10250,7 @@ Molpy.DefineBoosts = function() {
 		},
 		draglvl: 'Wyrm',
 		group: 'bean',
-		limit: function() { Molpy.Got('Dragonfly')?4:1 },
+		limit: function() { return Molpy.Got('Dragonfly')?4:1 },
 		defStuff: 1,
 		Spend: function() {
 			if (!this.bought) return false;


### PR DESCRIPTION
There was a missing return, the function was thus reporting an error so that Strength Potion was not available in the rewards list.