### PR TITLE
Fix display issue with the loot search box

### DIFF
--- a/classicstyle.css
+++ b/classicstyle.css
@@ -149,3 +149,6 @@
 	overflow-y:scroll;
 	width:560px;
 }
+#lootSearchBox {
+	box-sizing: border-box;
+}


### PR DESCRIPTION
On Chrome (40) and supposedly IE, the size of the <input> is too large, and its border overflows the div in the right margin.

box-sizing: border-box seems to fix this quite nicely in Chrome, but I haven't tested any other browsers.