### PR TITLE
ZooKeeper unlock change

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -4101,6 +4101,7 @@ Molpy.DefineBoosts = function() {
 				if(print == 'DMC' && !Molpy.Got('DMF')) continue;
 				if(print == 'DMB' && !Molpy.Got('DMC')) continue;
 				if(print == 'DMP' && !Molpy.Got('DMB')) continue;
+				if(print == 'ZK' && Molpy.Redacted.totalClicks <= 2500) continue;
 				return Molpy.blackprintCosts[print]; // number of pages needed for next blackprint boost
 			}
 		}

--- a/boosts.js
+++ b/boosts.js
@@ -4123,6 +4123,7 @@ Molpy.DefineBoosts = function() {
 				if(print == 'DMC' && !Molpy.Got('DMF')) continue;
 				if(print == 'DMB' && !Molpy.Got('DMC')) continue;
 				if(print == 'DMP' && !Molpy.Got('DMB')) continue;
+				if(print == 'ZK' && Molpy.Redacted.totalClicks <= 2500) continue;
 				if(Molpy.Level('Blackprints') >= Molpy.blackprintCosts[print]) return print;
 				return;
 			}


### PR DESCRIPTION
ZooKeeper can no longer be unlocked before it can be used.