### PR TITLE
Safety Net power visible, no longer resets on MD

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -572,19 +572,35 @@ Molpy.DefineBoosts = function() {
 	new Molpy.Boost({
 		name: 'Doublepost',
 		icon: 'doublepost',
-		desc: function(me) {
+		desc: 'During LongPix, Castle Tools activate a second time.',
+		price:{
+			Sand: '650K',
+			Castles: 4000
+		},
+		stats: function(me) {
+			var target = Molpy.SafetyTarget();
 			return 'During LongPix, Castle Tools activate a second time.'
 				+ '<br>Returning to shortpix will '
 				+ (Molpy.Got('Safety Blanket') ? 'disable' : 'lock')
 				+ ' this boost.'
 				+ '<br>You have done this ' + Molpy.Boosts['Safety Net'].power
-				+ ' time' + plural(Molpy.Boosts['Safety Net'].power) + '.';
-		},
-		price:{
-			Sand: '650K',
-			Castles: 4000
+				+ ' time' + plural(Molpy.Boosts['Safety Net'].power) + '.'
+				+ (target[0] ? ('<br>Next boost at: ' + Molpify(target[0], 3)) : '');
 		},
 	});
+	
+	Molpy.SafetyTarget = function() {
+		if(!Molpy.Boosts['Safety Net'].unlocked)
+			return [10, 'Safety Net'];
+		if(!Molpy.Boosts['Safety Blanket'].unlocked)
+			return [50, 'Safety Blanket'];
+		if(Molpy.Got('Vacuum Cleaner') && !Molpy.Boosts['Overtime'].unlocked)
+			return [222, 'Overtime'];
+		if(Molpy.Got('Overtime') && !Molpy.Boosts['Time Dilation'].unlocked)
+			return [555, 'Time Dilation'];
+		return [0, ''];
+	};
+	
 	new Molpy.Boost({
 		name: 'Coma Molpy Style',
 		icon: 'comamolpystyle',

--- a/boosts.js
+++ b/boosts.js
@@ -572,7 +572,14 @@ Molpy.DefineBoosts = function() {
 	new Molpy.Boost({
 		name: 'Doublepost',
 		icon: 'doublepost',
-		desc: 'During LongPix, Castle Tools activate a second time',
+		desc: function(me) {
+			return 'During LongPix, Castle Tools activate a second time.'
+				+ '<br>Returning to shortpix will '
+				+ (Molpy.Got('Safety Blanket') ? 'disable' : 'lock')
+				+ ' this boost.'
+				+ '<br>You have done this ' + Molpy.Boosts['Safety Net'].power
+				+ ' time' + plural(Molpy.Boosts['Safety Net'].power) + '.';
+		},
 		price:{
 			Sand: '650K',
 			Castles: 4000

--- a/castle.js
+++ b/castle.js
@@ -3331,12 +3331,10 @@ Molpy.Up = function() {
 		if(np <= 240) {
 			Molpy.NPlength = 1800;
 			if(Molpy.Got('Doublepost')) {
-				Molpy.Boosts['Safety Net'].power++;
-				if(Molpy.Boosts['Safety Net'].power >= 10) Molpy.UnlockBoost('Safety Net');
-				if(Molpy.Got('Safety Net') && Molpy.Boosts['Safety Net'].power >= 50)
-					Molpy.UnlockBoost('Safety Blanket');
-				if (Molpy.Boosts['Safety Net'].power >= 222 && Molpy.Got('Vacuum Cleaner')) Molpy.UnlockBoost('Overtime') 
-				if (Molpy.Boosts['Safety Net'].power >= 555 && Molpy.Got('Overtime')) Molpy.UnlockBoost('Time Dilation') 
+				var incidents = ++Molpy.Boosts['Safety Net'].power;
+				var target = Molpy.SafetyTarget();
+				if(target[0] && incidents >= target[0])
+					Molpy.UnlockBoost(target[1]);
 			}
 			if(!Molpy.Got('Safety Blanket')) {
 				Molpy.LockBoost('Overcompensating');

--- a/persist.js
+++ b/persist.js
@@ -1240,6 +1240,7 @@
 			var boj = !coma && Molpy.Got('BoJ') && Molpy.Spend('Bonemeal', 10000);
 			var KaKPower = !coma && Molpy.Got('Kite and Key') ? Molpy.Boosts['Kite and Key'].power : 0;
 			var LiBPower = !coma && Molpy.Got('Lightning in a Bottle') ? Molpy.Boosts['Lightning in a Bottle'].power : 0;
+			var SNPower = !coma && Molpy.Got('Safety Net') ? Molpy.Boosts['Safety Net'].power : 0;
 			var bagCount = boh + bom + bof + boj;
 			var maxKeep = Math.pow(1e42, bagCount);
 			var prizeCounts = [];
@@ -1277,6 +1278,7 @@
 			
 			Molpy.Boosts['Kite and Key'].power = KaKPower;
 			Molpy.Boosts['Lightning in a Bottle'].power = LiBPower;
+			Molpy.Boosts['Safety Net'].power = SNPower;
 			
 			Molpy.RatesRecalculate();
 			Molpy.allNeedRepaint = 1;


### PR DESCRIPTION
This fixes Issue #1319.  I tested this to make sure the boosts still unlock properly.  I ended up writing a Molpy.SafetyTarget() helper function like AD's Molpy.DragonTarget() in order to display the next target in Doublepost's stats, so I also changed Molpy.HandlePeriods() to use that for unlocks, which is a bit less clunky than the old code.