### PR TITLE
Try to prevent invisible logicats

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -878,7 +878,7 @@ Molpy.DefineGUI = function() {
 		} else if(specialIndex > 0){
 			redDiv.children().eq(specialIndex).before(Molpy.Redacted.getDiv());
 		}
-		if (Molpy.Redacted.keepPosition == 1) {
+		if (Molpy.Redacted.keepPosition == 1 && specialIndex != -1) {
 //			Molpy.Notify('Setting keepPosition to 2',1);
 			Molpy.Redacted.keepPosition=2;
 		}


### PR DESCRIPTION
Sometimes it seems that logicats do not properly appear, this is the simplest change that might fix that.

If a logicat would appear next to loot that is not currently visible (different page, category hidden), lootArray[...].hasDiv() seems to return false and therefore specialIndex is never set. At specialIndex == -1, the Redacted div never gets placed anywhere, but for logicats keepPosition is then set to 2, so no further attempts are made until it times out and the next redundakitty appears.

Observations:
The loot categories sometimes don't change to indicate the logicat, but at least it appears if you browse through them
The logicats seem to jump to the front of the loot page after a mNP