### PR TITLE
Gives IP and FindThings a speedboost

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -5234,12 +5234,12 @@ Molpy.DefineBoosts = function() {
 	{
 		if(times && Molpy.IsEnabled('Mario')) {
 			var l = Molpy.Boosts['Mario'].bought;
-			var runs=0
+			var runs=101
 			var cost = l * (l + 1) / 2;
 			Molpy.boostSilence++;
 			if(Molpy.Spend('QQ', cost)) {
-				while((l>0)&&(runs<500)) {
-					runs++
+				while((l>0)&&(runs>1)) {
+					runs-=1
 					Molpy.RewardLogicat(Molpy.Level('QQ'),Math.ceil(l/runs));
 				}
 			}

--- a/boosts.js
+++ b/boosts.js
@@ -5234,11 +5234,13 @@ Molpy.DefineBoosts = function() {
 	{
 		if(times && Molpy.IsEnabled('Mario')) {
 			var l = Molpy.Boosts['Mario'].bought;
+			var runs=0
 			var cost = l * (l + 1) / 2;
 			Molpy.boostSilence++;
 			if(Molpy.Spend('QQ', cost)) {
-				while(l--) {
-					Molpy.RewardLogicat(Molpy.Level('QQ'));
+				while((l>0)&&(runs<500)) {
+					runs++
+					Molpy.RewardLogicat(Molpy.Level('QQ'),Math.ceil(l/runs));
 				}
 			}
 			Molpy.boostSilence--;

--- a/castle.js
+++ b/castle.js
@@ -1752,7 +1752,9 @@ Molpy.Up = function() {
 						}
 					}
 				} else{
-					//if(!Molpy.boostSilence) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")
+					//if(!Molpy.boostSilence&&times!==13) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")
+					//if(!Molpy.boostSilence&&times===13) Molpy.Notify("Robotic Shopper saw no evil, so it did all the evil.")
+					Molpy.UnlockRepeatableBoost(bacon,auto,1)
 				}
 			}
 		}

--- a/castle.js
+++ b/castle.js
@@ -1783,8 +1783,11 @@ Molpy.Up = function() {
 		Molpy.DragonRewardOptions=Molpy.BoostsByFunction(function(i){
 			return (Molpy.Boosts[i].draglvl!==undefined)&&(Molpy.Boosts[i].draglvl!=='undefined')
 		})
-		Molpy.LogicRewardOptions=Molpy.BoostsByFunction(function(i){
+		Molpy.LogicatRewardOptions=Molpy.BoostsByFunction(function(i){
 			return (Molpy.Boosts[i].logic!==undefined)&&(Molpy.Boosts[i].logic!=='undefined')
+		})
+		Molpy.DepartmentRewardOptions=Molpy.BoostsByFunction(function(i){
+			return (Molpy.Boosts[i].department!==undefined)&&(Molpy.Boosts[i].department!=='undefined')
 		})
 
 		Molpy.previewNP = 0;
@@ -2519,7 +2522,7 @@ Molpy.Up = function() {
 				Molpy.CheckDoRDRewards(automationLevel);
 
 				var availRewards = [];
-				for( var i in Molpy.Boosts) {
+				for( var i in Molpy.DepartmentRewardOptions) {
 					var me = Molpy.Boosts[i];
 					if(!me.unlocked && me.department) {
 						availRewards.push(me);
@@ -2772,7 +2775,7 @@ Molpy.Up = function() {
 		Molpy.RewardLogicat = function(level) {
 			Molpy.CheckLogicatRewards(0);
 			var availRewards = [];
-			for( var i in Molpy.Boosts) {
+			for( var i in Molpy.LogicatRewardOptions) {
 				var me = Molpy.Boosts[i];
 				if(!me.unlocked && me.logic && level >= me.logic) {
 					availRewards.push(me);

--- a/castle.js
+++ b/castle.js
@@ -2822,8 +2822,8 @@ Molpy.Up = function() {
 		Molpy.RewardLogicat = function(level,times) {
 			Molpy.CheckLogicatRewards(0);
 			var availRewards = [];
-			for( var i in Molpy.LogicatRewardOptions) {
-				var me = Molpy.Boosts[i];
+			for( var i=0;i<Molpy.LogicatRewardOptions.length;i++) {
+				var me = Molpy.Boosts[Molpy.LogicatRewardOptions[i]];
 				if(!me.unlocked && me.logic && level >= me.logic) {
 					availRewards.push(me);
 				}

--- a/castle.js
+++ b/castle.js
@@ -1709,7 +1709,13 @@ Molpy.Up = function() {
 		};
 		Molpy.UnlockRepeatableBoost = function(bacon, auto, times){
 			if(times===1){Molpy.UnlockBoost(bacon,auto)} else {
-				if(bacon=='vault'||bacon=='Vault'||bacon=='lockedvault'||bacon=='LockedVault'||bacon=='Locked Vault'){
+				if(bacon=='lockedvault'||bacon=='Locked Vault'){
+					
+				} else if(bacon=='Vault Key'){
+					
+				} else if(bacon=='Locked Crate'){
+					
+				} else{
 					
 				}
 			}
@@ -1796,10 +1802,10 @@ Molpy.Up = function() {
 		Molpy.DepartmentRewardOptions=Molpy.BoostsByFunction(function(i){
 			return (Molpy.Boosts[i].department!==undefined)&&(Molpy.Boosts[i].department!=='undefined')
 		})
-		Molpy.RepeatableBoost=['Locked Vault','LockedVault','vault','Vault'
-		'VaultKey','Vault Key', 'vaultkey'
-		'CrateKey', 'Crate Key','cratekey'
-		'LockedCrate','Locked Crate','Crate','crate'] //Each boost on its own line, please!
+		Molpy.RepeatableBoost=['Locked Vault',
+		'Vault Key', 'vaultkey',
+		'Crate Key','cratekey',
+		'Locked Crate'] //Each boost on its own line, please!
 
 		Molpy.previewNP = 0;
 

--- a/castle.js
+++ b/castle.js
@@ -1773,6 +1773,19 @@ Molpy.Up = function() {
 				}
 			}
 		}
+		Molpy.BoostsByFunction(bacon){
+			var grapevine=[]
+			for(var i in Molpy.Boosts){
+				if(bacon(Molpy.Boosts[i].alias)){grapevine.push(Molpy.Boosts[i].alias)}
+			}
+			return grapevine
+		}
+		Molpy.DragonRewardOptions=Molpy.BoostsByFunction(function(i){
+			return (Molpy.Boosts[i].draglvl!==undefined)&&(Molpy.Boosts[i].draglvl!=='undefined')
+		})
+		Molpy.LogicRewardOptions=Molpy.BoostsByFunction(function(i){
+			return (Molpy.Boosts[i].logic!==undefined)&&(Molpy.Boosts[i].logic!=='undefined')
+		})
 
 		Molpy.previewNP = 0;
 

--- a/castle.js
+++ b/castle.js
@@ -1709,14 +1709,50 @@ Molpy.Up = function() {
 		};
 		Molpy.UnlockRepeatableBoost = function(bacon, auto, times){
 			if(times===1){Molpy.UnlockBoost(bacon,auto)} else {
-				if(bacon=='lockedvault'||bacon=='Locked Vault'){
-					
-				} else if(bacon=='Vault Key'){
-					
-				} else if(bacon=='Locked Crate'){
-					
+				var RobbySee=Molpy.Boosts['Rob'];
+				var RobbyDo=[]
+				for(var thingy = 0; thingy <= RobbySee.bought; thingy++) {
+					var item = Molpy.BoostsById[thingy + 1];
+					if(item.power) {
+						RobbyDo.push(item.alias)
+					}
+				}
+				if(RobbyDo.indexOf(bacon)){
+					var lettuce=Molpy.Boosts[bacon];
+					if(!([undefined, 'undefined', function(){}].indexOf(lettuce.lockFunction))){
+						lettuce.power+=times
+						if(lettuce.name==='Locked Vault' && Molpy.IsEnabled('Aleph One')){
+							var pages=(lettuce.power+lettuce.power-times)*times/2
+							if(Molpy.Got('VV')) pages = Molpy.VoidStare(pages, 'VV');
+							Molpy.Add('Blackprints', Math.floor(pages*Molpy.Papal('BlackP')));
+							if(Molpy.Got('Camera') && (Math.random() > Math.pow(0.9,times)) ) {
+								Molpy.EarnBadge('discov' + Math.ceil(Molpy.newpixNumber * Math.random()));
+							} //less efficient than normal vault opening, but that's too hard.
+							if(Molpy.Got('FluxCrystals')&&(Molpy.Got('Temporal Rift')||Molpy.Got('Flux Surge'))){
+								var c = Math.floor(Molpy.Level('AC') / 1000) * (1 + Molpy.Got('TDE'));
+								c=c*times
+								if (c && !Molpy.boostSilence) 
+									Molpy.Notify('You found '+Molpify(c)+' flux crystal'+plural(c)+'.');
+									Molpy.Add('FluxCrystals',Math.floor(Molpy.Level('AC')/1000)*(1+Molpy.Got('TDE')));
+							}
+						}
+						if(lettuce.name==='Vault Key'){Molpy.UnlockRepeatableBoost('Locked Vault',1,Math.floor(times/5))}
+						if(lettuce.name==='Crate Key'){Molpy.UnlockRepeatableBoost('Locked Crate',1,Math.floor(times/5))}
+						if(lettuce.name==='Locked Crate'){
+							var bl = Molpy.Boosts['GlassBlocks'];
+							var win = Math.ceil(Molpy.LogiMult('2K'));
+							lettuce.CrateCount+=times;
+							win = Math.floor(win / (6 - lettuce.bought));
+
+							if(bl.bought * 50 < bl.power + win) bl.bought = Math.ceil((bl.power + win) / 50); // make space!
+							Molpy.Add('GlassBlocks', win*times);
+							Molpy.Notify('+' + Molpify(win, 3) + ' Glass Blocks!');
+							if(Molpy.Got('Camera')) Molpy.EarnBadge('discov' + Math.ceil(Molpy.newpixNumber * Math.random()));
+							Molpy.Add('Blackprints', lettuce.bought*times);
+						}
+					}
 				} else{
-					
+					//if(!Molpy.boostSilence) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")
 				}
 			}
 		}

--- a/castle.js
+++ b/castle.js
@@ -1824,7 +1824,7 @@ Molpy.Up = function() {
 				}
 			}
 		}
-		Molpy.BoostsByFunction(bacon){
+		Molpy.BoostsByFunction=function(bacon){
 			var grapevine=[]
 			for(var i in Molpy.Boosts){
 				if(bacon(Molpy.Boosts[i].alias)){grapevine.push(Molpy.Boosts[i].alias)}

--- a/castle.js
+++ b/castle.js
@@ -2569,8 +2569,8 @@ Molpy.Up = function() {
 				Molpy.CheckDoRDRewards(automationLevel);
 
 				var availRewards = [];
-				for( var i in Molpy.DepartmentRewardOptions) {
-					var me = Molpy.Boosts[i];
+				for( var i=0;i<Molpy.DepartmentRewardOptions.length;i++) {
+					var me = Molpy.Boosts[Molpy.DepartmentRewardOptions[i]];
 					if(!me.unlocked && me.department) {
 						availRewards.push(me);
 					}

--- a/castle.js
+++ b/castle.js
@@ -1707,6 +1707,13 @@ Molpy.Up = function() {
 				}
 			}
 		};
+		Molpy.UnlockRepeatableBoost = function(bacon, auto, times){
+			if(times===1){Molpy.UnlockBoost(bacon,auto)} else {
+				if(bacon=='vault'||bacon=='Vault'||bacon=='lockedvault'||bacon=='LockedVault'||bacon=='Locked Vault'){
+					
+				}
+			}
+		}
 		Molpy.GiveTempBoost = function(bacon, power, countdown, desc) {
 			var bb = Molpy.Boosts[bacon];
 			if(bb) {
@@ -1789,6 +1796,10 @@ Molpy.Up = function() {
 		Molpy.DepartmentRewardOptions=Molpy.BoostsByFunction(function(i){
 			return (Molpy.Boosts[i].department!==undefined)&&(Molpy.Boosts[i].department!=='undefined')
 		})
+		Molpy.RepeatableBoost=['Locked Vault','LockedVault','vault','Vault'
+		'VaultKey','Vault Key', 'vaultkey'
+		'CrateKey', 'Crate Key','cratekey'
+		'LockedCrate','Locked Crate','Crate','crate'] //Each boost on its own line, please!
 
 		Molpy.previewNP = 0;
 
@@ -2772,7 +2783,7 @@ Molpy.Up = function() {
 			Molpy.GiveTempBoost('Blitzing', blitzSpeed, blitzTime);
 		};
 
-		Molpy.RewardLogicat = function(level) {
+		Molpy.RewardLogicat = function(level,times) {
 			Molpy.CheckLogicatRewards(0);
 			var availRewards = [];
 			for( var i in Molpy.LogicatRewardOptions) {
@@ -2785,8 +2796,12 @@ Molpy.Up = function() {
 			if(availRewards.length) {
 				var red = GLRschoice(availRewards);
 				if(!Molpy.IsFree(red.CalcPrice(red.price))) {
-					if(!Molpy.boostSilence) Molpy.Notify('Logicat rewards you with:', 1);
-					Molpy.UnlockBoost(red.alias, 1);
+					if(!Molpy.RepeatableBoost.indexof(red.alias)){
+						if(!Molpy.boostSilence) Molpy.Notify('Logicat rewards you with:', 1);
+						Molpy.UnlockBoost(red.alias, 1);
+					} else{
+						Molpy.UnlockRepeatableBoost(red.alias,1,times)
+					}
 				} else {
 					if(!Molpy.boostSilence) Molpy.Notify('Your reward from Logicat:', 1);
 					Molpy.GiveTempBoost(red.alias);

--- a/castle.js
+++ b/castle.js
@@ -1831,15 +1831,7 @@ Molpy.Up = function() {
 			}
 			return grapevine
 		}
-		Molpy.DragonRewardOptions=Molpy.BoostsByFunction(function(i){
-			return (Molpy.Boosts[i].draglvl!==undefined)&&(Molpy.Boosts[i].draglvl!=='undefined')
-		})
-		Molpy.LogicatRewardOptions=Molpy.BoostsByFunction(function(i){
-			return (Molpy.Boosts[i].logic!==undefined)&&(Molpy.Boosts[i].logic!=='undefined')
-		})
-		Molpy.DepartmentRewardOptions=Molpy.BoostsByFunction(function(i){
-			return (Molpy.Boosts[i].department!==undefined)&&(Molpy.Boosts[i].department!=='undefined')
-		})
+		
 		Molpy.RepeatableBoost=['Locked Vault',
 		'Vault Key', 'vaultkey',
 		'Crate Key','cratekey',

--- a/castle.js
+++ b/castle.js
@@ -3538,4 +3538,13 @@ window.onload = function() {
 		Molpy.Wake();
 		_gaq && _gaq.push(['_trackEvent', 'Setup', 'Complete', '' + Molpy.version, true]);
 	}
+	Molpy.DragonRewardOptions=Molpy.BoostsByFunction(function(i){
+		return (Molpy.Boosts[i].draglvl!==undefined)&&(Molpy.Boosts[i].draglvl!=='undefined')
+	})
+	Molpy.LogicatRewardOptions=Molpy.BoostsByFunction(function(i){
+		return (Molpy.Boosts[i].logic!==undefined)&&(Molpy.Boosts[i].logic!=='undefined')
+	})
+	Molpy.DepartmentRewardOptions=Molpy.BoostsByFunction(function(i){
+		return (Molpy.Boosts[i].department!==undefined)&&(Molpy.Boosts[i].department!=='undefined')
+	}) // These three should be elsewhere. Please let me know where elsewhere is.
 };

--- a/dragons.js
+++ b/dragons.js
@@ -581,8 +581,8 @@ Molpy.DragonDigging = function(type) { // type:0 = mnp, 1= beach click
 Molpy.FindThings = function() {
 	var dqlevel = Molpy.Level('DQ');
 	var availRewards = [];
-	for( var i in Molpy.DragonRewardOptions) {
-		var me = Molpy.Boosts[i];
+	for( var i=0;i<Molpy.DragonRewardOptions.length;i++) {
+		var me = Molpy.Boosts[Molpy.DragonRewardOptions[i]];
 		if("draglvl" in me && Molpy.Dragons[me.draglvl].id <= dqlevel) {
 			var lim = EvalMaybeFunction((me.limit || 1),me);      
 			if (me.unlocked < lim && me.unlocked == me.bought) availRewards.push(me);

--- a/dragons.js
+++ b/dragons.js
@@ -581,7 +581,7 @@ Molpy.DragonDigging = function(type) { // type:0 = mnp, 1= beach click
 Molpy.FindThings = function() {
 	var dqlevel = Molpy.Level('DQ');
 	var availRewards = [];
-	for( var i in Molpy.Boosts) {
+	for( var i in Molpy.DragonRewardOptions) {
 		var me = Molpy.Boosts[i];
 		if("draglvl" in me && Molpy.Dragons[me.draglvl].id <= dqlevel) {
 			var lim = EvalMaybeFunction((me.limit || 1),me);      


### PR DESCRIPTION
Draconic Plumbers!

Seriously, though, this should improve the game's runspeed.
As far as I can tell, this works as intended (fixing #1334). I even tried with mario.bought large enough to use E cubes/mNP without crashing. May require a bit more testing, but I do believe it works. In theory, FindThings will also be faster, but due to the messy nature of FindThings, it'll "only" be a few times as fast (scale with reward possibilities length instead of with Molpy.Boosts length). DoRD also got a speedup that works the same as FindThings.

One issue with IP that this does promote is RSI induced by spam-clicking upgrade/downgrade buttons :(.

EDIT: It clumped the runs into 500 groups. I'm not sure how many it should actually be. Changed it to 100 instead because that's faster. And fixed a dumb error. Also, the number of groups might need to be lowered.