### PR TITLE
Fixed a broken interaction with vault multibuy and shopping assitant

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -5234,13 +5234,13 @@ Molpy.DefineBoosts = function() {
 	{
 		if(times && Molpy.IsEnabled('Mario')) {
 			var l = Molpy.Boosts['Mario'].bought;
-			var runs=101
+			var runs=[10,20,100,500,1000][Molpy.options.approximation]
 			var cost = l * (l + 1) / 2;
 			Molpy.boostSilence++;
 			if(Molpy.Spend('QQ', cost)) {
-				while((l>0)&&(runs>1)) {
-					runs-=1
+				while((l>0)&&(runs>0)) {
 					Molpy.RewardLogicat(Molpy.Level('QQ'),Math.ceil(l/runs));
+					runs-=1
 				}
 			}
 			Molpy.boostSilence--;

--- a/castle.js
+++ b/castle.js
@@ -1717,6 +1717,7 @@ Molpy.Up = function() {
 						RobbyDo.push(item.alias)
 					}
 				}
+				RobbyDo.push(Molpy.shoppingItem)
 				if(RobbyDo.indexOf(bacon)){
 					var lettuce=Molpy.Boosts[bacon];
 					if(!([undefined, 'undefined', function(){}].indexOf(lettuce.lockFunction))){

--- a/options.js
+++ b/options.js
@@ -78,7 +78,8 @@ Molpy.OptionsFromString = function(thread) {
 // ALWAYS add to the end of this list. NEVER EVER remove an option
 Molpy.OptionSaveOrder = [ 'particles', 'numbers', 'autosave', 'autoupdate', 'sea', 'colpix', 'longpostfix', 'colourscheme',
 			  'sandmultibuy', 'castlemultibuy', 'fade', 'typo', 'science', 'autosavelayouts', 'autoscroll',
-			  'boostsort', 'european', 'smalldecimal', 'logicatcol', 'loglimit', 'autoshow', 'mindecimal', 'edigits' ];
+			  'boostsort', 'european', 'smalldecimal', 'logicatcol', 'loglimit', 'autoshow', 'mindecimal', 'edigits',
+			  'approx'];
 	
 // These options are defined in the display order
 
@@ -318,10 +319,19 @@ new Molpy.Option({ //Not Used
 	visability: -1,
 });
 
+new Molpy.Option({
+    name: 'approx',
+    title: 'Use rougher approximations',
+    range: 4,
+    text: ['Very Rough', 'Rough', 'Chunky', 'Smooth', 'Silky Smooth'],
+    visability: 1
+});
+
 /*
 new Molpy.Option({
 	name: '',
 	title: '',		
 });
 */
+
 


### PR DESCRIPTION
Does anyone even use the assistant? Either way, added a bit of code so you can also buy vaults from IP by means of the shopping assistant.

Also added an option that controls the groupings of IP so that those who wish and have faster computers can use more precision and those with slower ones can still run IP at high level without causing problems. The option itself is not specific to IP, so it can be reused for other approximations. The current grouping sizes are 10, 20, 100, 500, and 1000.