### PR TITLE
Fix QQ/IP w.r.t. vault/key/crate and notify

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -1763,6 +1763,7 @@ Molpy.Up = function() {
 							if(Molpy.Got('Camera')) Molpy.EarnBadge('discov' + Math.ceil(Molpy.newpixNumber * Math.random()));
 							Molpy.Add('Blackprints', lettuce.bought*times);
 						}
+						Molpy.Notify("Got "+Molpify(times)+bacon+Molpy.plural(times))
 					}
 				} else{
 					//if(!Molpy.boostSilence&&times!==13) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")

--- a/castle.js
+++ b/castle.js
@@ -1766,7 +1766,7 @@ Molpy.Up = function() {
 							if(Molpy.Got('Camera')) Molpy.EarnBadge('discov' + Math.ceil(Molpy.newpixNumber * Math.random()));
 							Molpy.Add('Blackprints', lettuce.bought*times);
 						}
-						Molpy.Notify("Got "+Molpify(times)+bacon+plural(times))
+						Molpy.Notify("Got "+Molpify(times)+' '+bacon+plural(times))
 					}
 				} else{
 					//if(!Molpy.boostSilence&&times!==13) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")

--- a/castle.js
+++ b/castle.js
@@ -1749,6 +1749,9 @@ Molpy.Up = function() {
 									Molpy.Add('FluxCrystals',Math.floor(Molpy.Level('AC')/1000)*(1+Molpy.Got('TDE')));
 							}
 						}
+						if(lettuce.name==='Locked Vault' && (!Molpy.IsEnabled('Aleph One'))){
+							Molpy.UnlockBoost('Locked Vault')
+						}
 						if(lettuce.name==='Vault Key'){Molpy.UnlockRepeatableBoost('Locked Vault',1,Math.floor(times/5))}
 						if(lettuce.name==='Crate Key'){Molpy.UnlockRepeatableBoost('Locked Crate',1,Math.floor(times/5))}
 						if(lettuce.name==='Locked Crate'){
@@ -1763,7 +1766,7 @@ Molpy.Up = function() {
 							if(Molpy.Got('Camera')) Molpy.EarnBadge('discov' + Math.ceil(Molpy.newpixNumber * Math.random()));
 							Molpy.Add('Blackprints', lettuce.bought*times);
 						}
-						Molpy.Notify("Got "+Molpify(times)+bacon+Molpy.plural(times))
+						Molpy.Notify("Got "+Molpify(times)+bacon+plural(times))
 					}
 				} else{
 					//if(!Molpy.boostSilence&&times!==13) Molpy.Notify("Robotic Shopper saw no evil, so it did no evil.")

--- a/castle.js
+++ b/castle.js
@@ -1726,7 +1726,7 @@ Molpy.Up = function() {
 				for(var thingy = 0; thingy <= RobbySee.bought; thingy++) {
 					var item = Molpy.BoostsById[thingy + 1];
 					if(item.power) {
-						RobbyDo.push(item.alias)
+						RobbyDo.push(item.name)
 					}
 				}
 				RobbyDo.push(Molpy.shoppingItem)
@@ -2840,6 +2840,7 @@ Molpy.Up = function() {
 			Molpy.Add('Panes', 1);
 		};
 		Molpy.RewardLogicat = function(level,times) {
+			if(times==undefined){times=1}
 			Molpy.CheckLogicatRewards(0);
 			var availRewards = [];
 			for( var i=0;i<Molpy.LogicatRewardOptions.length;i++) {


### PR DESCRIPTION
Tested at low IP power and works fine. Vaults/crates/keys have shorter notifications (just "got x locked vaults" instead of "logicat rewards you with:... locked vault"), but I think that's better for just about everyone. 

Note that this partly serves the same purpose as Calamitizer's pull, but also fixes the autobuy testing.