### PR TITLE
Add retro multibuy, nerf photo

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -12999,11 +12999,11 @@ new Molpy.Boost({
 	);
 	Molpy.splosions=function(n,a){
 		if(Molpy.Got('Concentrated Boom')){n=n*2}
-		var pow=5*n
+		var pow=10*n
 		var r=n
 		var l=25
 		while(r>0 && n>0){
-			pow=pow+Math.round(5*Math.ceil(r/l)*Math.random())
+			pow=pow+Math.round(15*Math.ceil(r/l)*Math.random())
 			r=r-Math.ceil(r/l)
 			l--
 		}
@@ -13016,11 +13016,11 @@ new Molpy.Boost({
 			r=r-Math.ceil(r/l)
 			l--
 		}
-		var blu=10*did[0]
-		var oth=10*did[1]
-		var whi=did[2]*0.5
-		var bla=did[3]*0.5
-		var gray=0.25*did[4]
+		var blu=25*did[0]
+		var oth=25*did[1]
+		var whi=did[2]*1
+		var bla=did[3]*1
+		var gray=0.5*did[4]
 		Molpy.Boosts['Blueness'].power+=blu
 		Molpy.Boosts['Otherness'].power+=oth
 		Molpy.Boosts['Whiteness'].power+=whi

--- a/boosts.js
+++ b/boosts.js
@@ -13003,7 +13003,7 @@ new Molpy.Boost({
 		var r=n
 		var l=25
 		while(r>0 && n>0){
-			pow=pow+Math.round(10*Math.ceil(r/l)*Math.random())
+			pow=pow+Math.round(5*Math.ceil(r/l)*Math.random())
 			r=r-Math.ceil(r/l)
 			l--
 		}
@@ -13016,11 +13016,11 @@ new Molpy.Boost({
 			r=r-Math.ceil(r/l)
 			l--
 		}
-		var blu=25*did[0]
-		var oth=25*did[1]
-		var whi=did[2]
-		var bla=did[3]
-		var gray=0.5*did[4]
+		var blu=10*did[0]
+		var oth=10*did[1]
+		var whi=did[2]*0.5
+		var bla=did[3]*0.5
+		var gray=0.25*did[4]
 		Molpy.Boosts['Blueness'].power+=blu
 		Molpy.Boosts['Otherness'].power+=oth
 		Molpy.Boosts['Whiteness'].power+=whi
@@ -13046,7 +13046,7 @@ new Molpy.Boost({
 			},
 			
 			lockFunction: function() {
-				Molpy.Boosts['Ocean Blue'].power=Math.max(Molpy.Boosts['Ocean Blue'].power-2,1);
+				Molpy.Boosts['Ocean Blue'].power=Math.max(Molpy.Boosts['Ocean Blue'].power/2-1,1);
 				Molpy.Notify('It is an eloquent boom, but it is still a boom.')
 			},
 				
@@ -13058,7 +13058,7 @@ new Molpy.Boost({
 			}
 		}
 	);
-	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10})) Molpy.UnlockBoost(alias)}
+	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10)))})) Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
 	new Molpy.Boost({
 			name: 'Retroactivity',
 			desc: function(me){
@@ -13072,7 +13072,7 @@ new Molpy.Boost({
 					}
 					for(var i=0;i<avoptions.length;i++){
 						var look=Molpy.Boosts[avoptions[i]]
-						str=str+"<br>Assume you have "
+						str=str+"<br>Assume you have "+Molpify(Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))
 						str=str+"<input type='Button' onclick='Molpy.RetroAct(\"" 
 						str=str+ look.alias + "\")' value='" + look.name+"'></input>" //Yup. Assume.
 					}

--- a/boosts.js
+++ b/boosts.js
@@ -13058,7 +13058,7 @@ new Molpy.Boost({
 			}
 		}
 	);
-	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10)))})) Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
+	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10)))})) Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
 	new Molpy.Boost({
 			name: 'Retroactivity',
 			desc: function(me){
@@ -13072,7 +13072,7 @@ new Molpy.Boost({
 					}
 					for(var i=0;i<avoptions.length;i++){
 						var look=Molpy.Boosts[avoptions[i]]
-						str=str+"<br>Assume you have "+Molpify(Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))
+						str=str+"<br>Assume you have "+Molpify(Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10))))
 						str=str+"<input type='Button' onclick='Molpy.RetroAct(\"" 
 						str=str+ look.alias + "\")' value='" + look.name+"'></input>" //Yup. Assume.
 					}

--- a/boosts.js
+++ b/boosts.js
@@ -13058,7 +13058,8 @@ new Molpy.Boost({
 			}
 		}
 	);
-	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10)))})) Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
+	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10)))})){
+		if(Math.random()>Molpy.Boosts['Retroactivity'].power^(Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))){Molpy.Notify('A Contradiction ocurred!');Molpy.UnlockRepeatableBoost('splosion',1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))} else{Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
 	new Molpy.Boost({
 			name: 'Retroactivity',
 			desc: function(me){

--- a/boosts.js
+++ b/boosts.js
@@ -12737,7 +12737,7 @@ new Molpy.Boost({
 	);
 	Molpy.getSquids=function(){
 		if(!Molpy.Got('Argy')){return 0;}
-		Molpy.Boosts['Argy'].power=Math.max(Molpy.Boosts['Blackness'].power,1)
+		Molpy.Boosts['Argy'].power=Math.max(DeMolpify(Molpy.Boosts['Blackness'].power),1)
 		return Math.pow(10,Math.floor(Math.log(Molpy.Boosts['Argy'].power)/Math.log(10)))
 	}
 	Molpy.makeSquids=function(n){

--- a/boosts.js
+++ b/boosts.js
@@ -13086,6 +13086,7 @@ new Molpy.Boost({
 			price: {
 				Grayness:12.5*10
 			},
+			startPower:0.6,
 			buyFunction: function(){Molpy.PhotoRewardOptions.splice(Molpy.PhotoRewardOptions.indexOf(this.alias),1)}//a must :(
 		}
 	);

--- a/boosts.js
+++ b/boosts.js
@@ -13079,6 +13079,7 @@ new Molpy.Boost({
 				}
 				return str
 			},
+			stats: "Assumed itself into existence.",
 			group: 'varie',
 			photo: 2, //not the easiest to get. I don't mind, though.
 			price: {

--- a/boosts.js
+++ b/boosts.js
@@ -12927,6 +12927,7 @@ new Molpy.Boost({
 				}
 				return str;
 			},
+			stats: "Renamed Phlogiston to anti-grayness. But, since that doesn't make any sense, it was declared Phlogiston could not be a correct theory.",
 			group: 'varie',
 			IsEnabled: Molpy.BoostFuncs.PosPowEnabled,
 			className: 'toggle',
@@ -12971,6 +12972,7 @@ new Molpy.Boost({
 	new Molpy.Boost({
 			name: 'Photoelectricity',
 			desc: 'Lets Not a Priest be disabled and does stuff when it is disabled.',
+			stats: "In the element 1921, Eisenstein was awarded the Metal of Nobility for his work in emcee. Wait. That last part wasn't right.",
 			group: 'varie',
 			price: {
 				Whiteness: 12.5*10

--- a/boosts.js
+++ b/boosts.js
@@ -12994,7 +12994,7 @@ new Molpy.Boost({
 			desc: "Enough of these, and you'll get a... nevermind.",
 			group: 'varie',
 			photo: 1,
-			buyFunction: function(){Molpy.LockBoost(this.alias);Molpy.Boosts['bluhint'].power++}
+			buyFunction: function(){Molpy.LockBoost(this.alias);Molpy.Boosts['bluhint'].power+=0.05}
 		}
 	);
 	Molpy.splosions=function(n,a){

--- a/boosts.js
+++ b/boosts.js
@@ -743,7 +743,7 @@ Molpy.DefineBoosts = function() {
 			Molpy.EarnBadge('The Big Freeze');
 			return;
 		}
-		if(Math.abs(np) > Math.abs(Molpy.highestNPvisited)) {
+		if(Math.abs(np) > Math.abs(Molpy.largestNPvisited[Number((np-Math.floor(np)).toFixed(3))])) {
 			Molpy.Notify('Wait For It');
 			return;
 		}

--- a/boosts.js
+++ b/boosts.js
@@ -13059,7 +13059,9 @@ new Molpy.Boost({
 		}
 	);
 	Molpy.RetroAct=function(alias){if(Molpy.Spend({Grayness:10*Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10)))})){
-		if(Math.random()>Molpy.Boosts['Retroactivity'].power^(Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))){Molpy.Notify('A Contradiction ocurred!');Molpy.UnlockRepeatableBoost('splosion',1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))} else{Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))}
+		if(Math.random()>(Math.max(0,-0.001+Molpy.Boosts['Retroactivity'].power^(Math.pow(10,Math.floor(Math.log(Math.max(Molpy.Boosts['Grayness'].power,1))/Math.log(10))))))){Molpy.Notify('A Contradiction ocurred!');
+		Molpy.UnlockRepeatableBoost('splosion',1,Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10))))
+		} else{Molpy.UnlockRepeatableBoost(alias,1,Math.pow(10,Math.floor(0.5*Math.log(Math.max(Molpy.Boosts['Grayness'].power/10,1))/Math.log(10))))}
 	new Molpy.Boost({
 			name: 'Retroactivity',
 			desc: function(me){
@@ -13086,7 +13088,7 @@ new Molpy.Boost({
 			price: {
 				Grayness:12.5*10
 			},
-			startPower:0.6,
+			startPower:0.4,
 			buyFunction: function(){Molpy.PhotoRewardOptions.splice(Molpy.PhotoRewardOptions.indexOf(this.alias),1)}//a must :(
 		}
 	);

--- a/castle.js
+++ b/castle.js
@@ -3295,7 +3295,7 @@ Molpy.Up = function() {
 			}
 			if(Molpy.Got('pH')){
 				Molpy.Boosts['pH'].power++
-				var t=10000000/(25*12.5)
+				var t=10000000/(25*2.5)
 				if(Molpy.Got('pOH')){t=10}
 				if(Molpy.Boosts['pH'].power>=t){Molpy.RunFastPhoto(25);Molpy.Boosts['pH'].power=0;
 					Molpy.EarnBadge('pH');if(!Molpy.Got('pOH')){Molpy.EarnBadge('pOHless')

--- a/castle.js
+++ b/castle.js
@@ -3339,7 +3339,9 @@ Molpy.Up = function() {
 		if(dif>2*Molpy.Boosts['Blackness'].power){dif=Math.ceil(Molpy.Boosts['Blackness'].power/2)}
 		if(dif>Molpy.Boosts['Whiteness'].power){dif=Molpy.Boosts['Whiteness'].power}
 		if(-dif>Molpy.Boosts['Grayness'].power){dif=-Molpy.Boosts['Grayness'].power}
-		dif=dif/2
+		if(max==1 && !Molpy.Got('Whiteness')){
+			Molpy.Notify("You made something, but it reacted with 2 of your blackness before you could see what it was")
+		}else{dif=dif/2}
 		Molpy.Boosts['Blackness'].power=Math.max(0,Molpy.Boosts['Blackness'].power-2*dif)
 		Molpy.Boosts['Whiteness'].power=Molpy.Boosts['Whiteness'].power-dif
 		if(Molpy.Got('NaP')&&(Molpy.IsEnabled('NaP')||!Molpy.Got('Photoelectricity'))){
@@ -3348,9 +3350,7 @@ Molpy.Up = function() {
 		if((Molpy.Got('NaP'))&&(!Molpy.IsEnabled('NaP'))){
 			Molpy.Boosts['Grayness'].power=Molpy.Boosts['Grayness'].power-brate/4
 		} //NaP defaults to on.
-		if(max==1 && !Molpy.Got('Whiteness')){
-			Molpy.Notify("You made something, but it reacted with 2 of your blackness before you could see what it was")
-		}
+		
 		return dif
 	}
 	Molpy.craftPhoto=function(){

--- a/gui.js
+++ b/gui.js
@@ -1270,7 +1270,7 @@ Molpy.DefineGUI = function() {
 	Molpy.subPixLetters = ['', 'a', 'b', 'c', 'd', 'e'];
 	Molpy.fixLength=function(a,l){
 		a=String(a)
-		if(a.length<l){return Molpy.fixLength('0'+a,l)} else{return a}
+		if(a.length<l){return Molpy.fixLength('0'+String(a),l)} else{return a}
 	}
 	Molpy.FormatNP = function(np, format) {
 		var minus = (np < 0);


### PR DESCRIPTION
Oh joy new ridiculously long line! The changes are as follows:

splosion cuts ocean blue in half and subtracts 1, but gives a bit more stuff. Retro has a chance to give splosion instead (60%, because it needed to be pretty big). Fragment is a lot less powerful (0.05x). Also, a minor bugfix to reinstate the intended puzzle surrounding whiteness. Also, a few misc. TaT fixes. And I added some more stats-views (to NaP and Photoelectricity)