### PR TITLE
Fix a Math.random that should have been Math.random()

### DIFF
--- a/dragons.js
+++ b/dragons.js
@@ -254,7 +254,7 @@ Molpy.Opponent = function(args) {
 				num = Math.floor(maxval * Math.random()+minval);
 			} else {
 				if (Math.random() < range + blitz){
-					if(range + blitz - Math.random > 1){
+					if(range + blitz - Math.random() > 1){
 						Molpy.EarnBadge('Two Pots O\' Gold');
 						second++;
 					}


### PR DESCRIPTION
It's possible the conditional I fixed was not intended to fire. If so, it should be commented out instead for clarity.