### PR TITLE
Blitzing lockFunction fix

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -320,9 +320,7 @@ Molpy.DefineBoosts = function() {
 		},
 		startCountdown: 23, // only used when loading to ensure it doesn't get stuck. any true value would do here
 		countdownCMS: 1,
-		countdownLockFunction: function() {
-			this.unlocked = 0;
-			this.bought = 0;
+		lockFunction: function() {
 			if(Molpy.Got('Sea Mining')){
 				Molpy.LockBoost('Sea Mining');
 			}


### PR DESCRIPTION
Using a custom countdownLockFunction bypasses the normal locking logic,
which results in UI and rates issues.  A lockFunction is called from
LockBoost as part of locking.

Fixes #1412 and #1410