### PR TITLE
Department Rewards continuting work

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -432,7 +432,8 @@ Molpy.DefineBoosts = function() {
 			this.prize = Molpy.GetDoor();
 		},
 
-		loadFunction: function() { Molpy.LockBoost('MHP') }
+		loadFunction: function() { Molpy.LockBoost('MHP') },
+		department: 0,
 	});
 	
 	Molpy.MontyDoors = ['A', 'B', 'C'];
@@ -854,6 +855,7 @@ Molpy.DefineBoosts = function() {
 			Sand: '2.5M',
 			Castles: 4400
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'HAL-0-Kitty',
@@ -1056,6 +1058,7 @@ Molpy.DefineBoosts = function() {
 			Sand: 88,
 			Castles: 88
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Bag Burning',
@@ -1478,7 +1481,8 @@ Molpy.DefineBoosts = function() {
 		stats: function() {
 			return 'Adds ' + Molpify(20 * Molpy.Boosts['BKJ'].power, 1) + '% to Not Lucky reward.<br>'
 				+ 'It also gets a boost from Blitzing if you get them simultaneously and allows Blitzing to improve Blast Furnace (though only up to 20% of Castles Built, before accounting for Flux Turbine).';
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'VITSSÅGEN, JA!',
@@ -1865,7 +1869,8 @@ Molpy.DefineBoosts = function() {
 				this.riftIMG.attr('src', ('img/rifts/rift_' + (this.variation + 1) + '_1.png'));
 			}
 			this.riftState = state;
-		}
+		},
+		department: 0,
 	});
 	
 	Molpy.RiftJump = function() {
@@ -3203,6 +3208,7 @@ Molpy.DefineBoosts = function() {
 			Sand: '200T',
 			Castles: '368G'
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Redunception',
@@ -3344,6 +3350,7 @@ Molpy.DefineBoosts = function() {
 			GlassBlocks: '500'
 
 		},
+		department: 0,
 	});
 
 	Molpy.ToggleBBC = function() {
@@ -5832,7 +5839,8 @@ Molpy.DefineBoosts = function() {
 			Sand: '10WW',
 			Castles: '10WW',
 			GlassBlocks: '12M',
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Break the Mould',
@@ -5843,7 +5851,8 @@ Molpy.DefineBoosts = function() {
 			Sand: '10WWW',
 			Castles: '10WWW',
 			GlassBlocks: '2M',
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'TF Load Letter',
@@ -5938,7 +5947,8 @@ Molpy.DefineBoosts = function() {
 		buyFunction: function() {
 			this.power |= 1;
 			if(Molpy.Earned('Nope!')) this.power = 6e51;
-		}
+		},
+		department: 0,
 	});
 	
 	Molpy.ControlToolFactory = function(n) {
@@ -5968,7 +5978,8 @@ Molpy.DefineBoosts = function() {
 			if(!n) n = 1;
 			if(Molpy.Got('LogiPuzzle')) Molpy.Add('LogiPuzzle', n * (1 + Molpy.Level('PR')));
 			Molpy.LockBoost(this.alias);
-		}
+		},
+		department: 0,
 	});
 	
 	Molpy.PokeBar = function() {
@@ -6027,7 +6038,8 @@ Molpy.DefineBoosts = function() {
 			Sand: Infinity,
 			Castles: Infinity,
 			GlassBlocks: '10M',
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Glassed Lightning',
@@ -6108,7 +6120,8 @@ Molpy.DefineBoosts = function() {
 			this.countdown = Math.min(500, this.countdown *= 1.21);
 			this.Refresh();
 			Molpy.Boosts['TDE'].Refresh();
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Automata Control',
@@ -6594,6 +6607,7 @@ Molpy.DefineBoosts = function() {
 			Castles: '15E',
 			GlassBlocks: '10K',
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Price Protection',
@@ -6680,6 +6694,7 @@ Molpy.DefineBoosts = function() {
 			Castles: Infinity,
 			GlassBlocks: '8Z',
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Dragon Forge',
@@ -6858,6 +6873,7 @@ Molpy.DefineBoosts = function() {
 			Castles: Infinity,
 			GlassBlocks: '230Z'
 		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Goats',
@@ -6908,7 +6924,8 @@ Molpy.DefineBoosts = function() {
 		icon: 'silvercard',
 		group: 'hpt',
 		desc: 'Affordable Swedish Home Furniture discount increased to 50% off',
-		price:{ Sand: '1G' }
+		price:{ Sand: '1G' },
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Gold Loyalty Card',
@@ -6916,7 +6933,8 @@ Molpy.DefineBoosts = function() {
 		icon: 'goldcard',
 		group: 'hpt',
 		desc: 'Affordable Swedish Home Furniture discount increased to 60% off',
-		price:{ Sand: '10T' }
+		price:{ Sand: '10T' },
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Stretchable Chip Storage',
@@ -7199,7 +7217,8 @@ Molpy.DefineBoosts = function() {
 		name: 'No Need to be Neat',
 		icon: 'noneedtobeneat',
 		desc: 'When you Molpy Down, the amount of one random type of tool is not reset to 0',
-		price:{ GlassBlocks: '50M' }
+		price:{ GlassBlocks: '50M' },
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Thunderbird',
@@ -10085,7 +10104,8 @@ Molpy.DefineBoosts = function() {
 			} else {
 				Molpy.Notify(Molpy.Boosts[s].name + ' has been constructed and is available for purchase', 1);
 			}
-		}
+		},
+		department: 0,
 	});
 	new Molpy.Boost({
 		name: 'Shadow Feeder',
@@ -11399,6 +11419,7 @@ Molpy.DefineBoosts = function() {
 		},
 		group: 'drac',
 		NotTemp: 1,
+		department: 0,
 		
 	});
 
@@ -11430,6 +11451,7 @@ Molpy.DefineBoosts = function() {
 			this.Lock();
 			Molpy.Overview.Update(Molpy.newpixNumber);
 		},
+		department: 0,
 	});
 
 	new Molpy.Boost({ 

--- a/data.js
+++ b/data.js
@@ -808,7 +808,7 @@ Molpy.CheckDoRDRewards = function(automationLevel) {
 	}
 	if(Molpy.Got('SBTF')) {
 		Molpy.Boosts['Castle Crusher'].department = 1;
-	}
+	} //these need an else or the result would be undefined and it wouldn't be on the list if we didn't force it.
 	if(Molpy.Earned('Ninja Omnipresence') && Molpy.Got('Active Ninja')) {
 		Molpy.Boosts['Ninja League'].department = 1;
 	}
@@ -821,21 +821,21 @@ Molpy.CheckDoRDRewards = function(automationLevel) {
 	} else {
 		Molpy.LockBoost('Redunception'); //prevent use in shortpix!
 		Molpy.Boosts['Redunception'].department = 0;
-	}
+	} //this one works
 	if(Molpy.Redacted.totalClicks >= 776) {
 		Molpy.Boosts['Logicat'].department = 1;
-	}
+	} //this one is falling back on the boost definition
 	if(Molpy.Redacted.totalClicks >= 431) {
 		Molpy.Boosts['Technicolour Dream Cat'].department = 1;
 	}
 
-	Molpy.Boosts['RRR'].department = 1 * (Molpy.Boosts['Panther Salve'].power > 200);
+	Molpy.Boosts['RRR'].department = 1 * (Molpy.Boosts['Panther Salve'].power > 200); //this works because you get 1 or 0 not 1 and undefined
 	Molpy.Boosts['Phonesaw'].department = 1 * (Molpy.Boosts['VJ'].power >= 88);
 
 	var found = 0;
 	for( var i in Molpy.jDipBoosts) {
 		var me = Molpy.Boosts[Molpy.jDipBoosts[i]];
-		if(found && !me.unlocked) me.department = 1;
+		if(found && !me.unlocked) me.department = 1; //1 and undefined
 		if(me.unlocked) found++;
 	}
 	if(found == Molpy.jDipBoosts.length) {
@@ -849,6 +849,10 @@ Molpy.CheckDoRDRewards = function(automationLevel) {
 
 	Molpy.Boosts['Fractal Fractals'].department = 1 * (Molpy.Boosts['Fractal Sandcastles'].power >= 120);
 
+	Molpy.Boosts['Locked Vault'].department = 0;
+	Molpy.Boosts['Vault Key'].department = 0;
+	Molpy.Boosts['Locked Crate'].department = 0;
+	Molpy.Boosts['Crate Key'].department = 0;
 	if(Molpy.Boosts['AC'].power && Molpy.Boosts['AC'].power > 180) {
 		Molpy.Boosts['Vault Key'].department = (Molpy.Boosts['Locked Vault'].unlocked || flandom(3) == 0
 			&& Molpy.Got('Keygrinder'))


### PR DESCRIPTION
This can be merged whenever the next batch of fixes is ready but I've discovered there is more work that should be done gradually to tidy up the code while assuring we don't re-break what the forced definitions are fixing.

I have added yet more boosts that people have reported that were apparently being missed due to the design of the reward list generation.

Adding .department to a bunch of boost definitions is a working fix but unlike .logic or .photo  which set levels the .department (and .kitten) definitions are almost always just true(1) or false(0) and so are not in need of fixed definition in the boosts.js once the real issue is addressed which appears to be that a fair number of the lines in data.js for the Molpy.CheckDoRDRewards function are written so that they set department to 1 or do nothing which leaves it undefined and trips up the list generation. We also have a bunch of lines scattered throughout other files setting .department and they could be consolidated into that single check function and if necessary also made to do both setting 1 and 0.

Additionally efforts could be taken for both Department and Logicat reward schemes to make them more like the photo reward scheme where boosts that are owned and should not be locking to be unlocked again are excluded from the list at generation as well as the change to the buy function that splices boosts out of the list when they are bought if they are not something that will relock, reunlock and need rebuying. As while these new lists are notably shorter than the full list of ~500 boosts, after all these fixes the additional inclusions bring both of the lists to around 50 entries each and we then check at least one of these lists if not both up to 50 times a mNP to tell Mario that of the 115 unique options at last check about five are the common valid choices.