### PR TITLE
Put notifications in front of the beach

### DIFF
--- a/common.css
+++ b/common.css
@@ -505,7 +505,7 @@ body.lightscheme .badge.loot h1
 	font-size:20px;
 	margin:20px;
 }
-#notifs {position:fixed;left:0px;top:0px;}
+#notifs {position:fixed;left:0px;top:0px;z-index:20;}
 .notif
 {
 	font-family:'Conv_xkcd-Regular',Sans-Serif;


### PR DESCRIPTION
On Chrome, in the classic layout, notifications are drawn behind the
beach.  Placing a z-index on the top-level notifications div fixes this.

Untested on other browsers / layouts.