### PR TITLE
Fix detecting the '5' key with numpads and azerty leopards

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -400,7 +400,16 @@ Molpy.Up = function() {
 
 		var prevKey = '';
 		Molpy.KeyDown = function(e) {
-			var key = String.fromCharCode(e.keyCode || e.charCode);
+			// Ignore Shift, Control, Alt
+			if(e.keyCode >= 0x10 && e.keyCode <= 0x14)
+				return;
+
+			var key;
+			if(e.keyCode >= 0x60 && e.keyCode <= 0x69) // Numpad
+				key = String.fromCharCode(e.keyCode - 0x30);
+			else
+				key = String.fromCharCode(e.keyCode || e.charCode);
+
 			if(key == '5' && prevKey.toLowerCase() == 'f') {
 				Molpy.ClickBeach(e, 1);
 				Molpy.EarnBadge('Use Your Leopard');


### PR DESCRIPTION
Clicking the beach requires to press 'f' then '5'. The detection of the
'5' key in all possible configurations is a bit tricky, because the
KeyboardEvent interface is such a mess.

Firstly, numpad keys have different keycodes (from 0x60 to 0x69 instead
of 0x30 to 0x39). So we need to check for them individually.

Secondly, on LaPetite's weird azerty leopard, digits in the top row
needs to be typed while holding shift (or control with some layouts).
Control keys are considered normal keys by onkeydown, so the code
remembers them as the previous key: the sequence becomes 'f' shift '5'.
So we test for these keys and ignore them.