### PR TITLE
Fix #1474

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -1891,9 +1891,10 @@ Molpy.DefineBoosts = function() {
 		}
 		if(Molpy.Got('Temporal Rift')) {
 			if(Molpy.Got('Safety Net'))
-				Molpy.newpixNumber = Math.round(Math.random() * (Math.abs(Molpy.highestNPvisited) - 241) + 241)
+				Molpy.newpixNumber = Math.ceil(Math.random() * (Math.abs(Molpy.largestNPvisited[0]) - 241) + 241)
 			else
-				Molpy.newpixNumber = Math.round(Math.random() * Math.abs(Molpy.highestNPvisited));
+				Molpy.newpixNumber = Math.ceil(Math.random() * Math.abs(Molpy.largestNPvisited[0]));
+
 			if(Molpy.Earned('Minus Worlds') && Molpy.Has('GlassChips',1000) && Math.floor(Math.random() * 2)) Molpy.newpixNumber *= -1;
 			Molpy.ONG();
 			Molpy.LockBoost('Temporal Rift');


### PR DESCRIPTION
When adding t1i, I forgot to handle rifts initially. Everything looked OK, albeit harsh (since they always lead to OTC). It wasn't OK, but #1474 was the only way it could go wrong for now so it's all good. The other potential issue I spotted was that if your current timeline's max NP was larger than your max NP in OTC, you could use temporal rifts to get ahead in OTC. Still, I'll admit it would be a funny easter egg for those who somehow were able to use it. Also, for simplicity, the code is now using `Math.ceil` instead of `Math.round`, so the chance of jumping to your max NP is a bit higher.