### PR TITLE
dragon equipment reward quick fix

### DIFF
--- a/dragons.js
+++ b/dragons.js
@@ -253,7 +253,7 @@ Molpy.Opponent = function(args) {
 				var maxval = DeMolpify(bits[1]);
 				num = Math.floor(maxval * Math.random()+minval);
 			} else {
-				if (Math.random() < range + blitz){
+				if ((Math.random() < range + blitz)||((range + blitz <= 0.10)&&(Math.random() < 0.10))){
 					if(range + blitz - Math.random() > 1){
 						Molpy.EarnBadge('Two Pots O\' Gold');
 						second++;


### PR DESCRIPTION
range for Thing combined with a blitzval that is too negative can trap players as they can't unlock new attack boosts. Picked a 10% minimum chance just because that seemed suitable to me.