### PR TITLE
Reset currentLog button when clearing logs

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1122,6 +1122,7 @@ Molpy.DefineGUI = function() {
 		Molpy.selectedLog = 0;
 		Molpy.notifLogPaint = 1;
 		Molpy.logUpdatePaint = 0;
+		g('logCurrent').value="Current";
 	}
 	Molpy.ClearLog();
 	Molpy.InMyPants = 0;


### PR DESCRIPTION
So it doesn't get stuck saying "\*NEW\*" when there are no logs at all.