### PR TITLE
Fix a typo

### DIFF
--- a/castle.js
+++ b/castle.js
@@ -3516,7 +3516,7 @@ Molpy.Up = function() {
 				if(!price){price={}}
 				if(!Molpy.IsFree(red.CalcPrice(price))) {
 					if(Molpy.RepeatableBoost.indexOf(red.alias) < 0){
-						if(!Molpy.boostSilence && !Molpy.got(red.alias)) 
+						if(!Molpy.boostSilence && !Molpy.Got(red.alias)) 
 							Molpy.Notify('Photoelectricity revealed:', 0);
 						Molpy.UnlockBoost(red.alias, 1);
 					} else{


### PR DESCRIPTION
Reported [here](https://www.reddit.com/r/SandcastleBuilder/comments/65eidq/game_error/)

This was a bit weird because it seemed to cause problems with NaP disactivated, when clicking (of course, due to the fact that photoelectricity mainly runs when you click).