### PR TITLE
fix a couple issues with exit through the abattoir

### DIFF
--- a/boosts.js
+++ b/boosts.js
@@ -7294,6 +7294,10 @@ Molpy.DefineBoosts = function() {
 	Molpy.ShadowStrike = function() {
 		Molpy.Anything = 1;
 		var l = Molpy.Level('LogiPuzzle') / 100;
+		if (l === 0) {
+			// this was combining with an infinite multiplier from Abattoir to make mustard
+			return;
+		}
 		var n = Math.ceil(l);
 		var p = n - l;
 		if (n < 1000000) {
@@ -7302,7 +7306,7 @@ Molpy.DefineBoosts = function() {
 			if (Math.random() < 0.25) n = 1;
 		}
 		if (n>1 && Molpy.Got('Panthers Dream')) n*=Molpy.Boosts['CDSP'].power;
-		if (Molpy.Got('Abattoir') == Molpy.Boosts['Abattoir'].limit) n *= Math.pow(1.1, Molpy.Boosts['Abattoir'].power);
+		if (n>1 && Molpy.Got('Abattoir') == Molpy.Boosts['Abattoir'].limit) n *= Math.pow(1.1, Molpy.Boosts['Abattoir'].power);
 		n = Math.floor(n*Molpy.Papal('Bonemeal'));
 		n = Math.min(n,1e290);
 		if (!Molpy.boostSilence) Molpy.Notify('The Shadow Dragon was ' + (n == 1 ? 'greedy' : 'generous') + ' and turned ' + Molpify(Molpy.Level('LogiPuzzle')) + ' Caged Logicat puzzles into ' + Molpify(n) + ' Bonemeal.', 0);


### PR DESCRIPTION
The Abattoir multiplier is currently being applied even when the shadow dragon is greedy or when it runs with 0 logicats, which can happen via Shadow Coda.  In the 0 logicats case, this results in mustard bonemeal if the Abattoir multiplier is infinite.

Checking for `n > 1` fixes both these issues, but I felt it was sensible to also return early if there are no logicats since it shouldn't be running anyways.